### PR TITLE
Add a webhook from Travis to Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,14 @@
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170728065612"
+editor:
+  name: "AddTravisWebhook"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.2.62"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs"
+    branch: "nortissej/suggest-build-integration"
+    sha: "0cb3bb6"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 
+
+        PRETEND I JUST ADDED A WEBHOOK


### PR DESCRIPTION
Created by Atomist Editor `AddTravisWebhook`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170728065612"
editor:
  name: "AddTravisWebhook"
  group: "atomist"
  artifact: "enrollment-rugs"
  version: "0.2.62"
  origin:
    repo: "git@github.com:atomisthq/enrollment-rugs"
    branch: "nortissej/suggest-build-integration"
    sha: "0cb3bb6"

```